### PR TITLE
feat: add custom json serializer support

### DIFF
--- a/src/defaultJsonSerializer.ts
+++ b/src/defaultJsonSerializer.ts
@@ -1,0 +1,6 @@
+import { JsonSerializer } from "./types.dom";
+
+export const defaultJsonSerializer: JsonSerializer = {
+  parse: JSON.parse,
+  stringify: JSON.stringify
+}

--- a/src/types.dom.ts
+++ b/src/types.dom.ts
@@ -278,6 +278,11 @@ interface AbortSignal extends EventTarget {
   ): void
 }
 
+export interface JsonSerializer {
+  stringify(obj: any): string;
+  parse(obj: string): unknown;
+}
+
 export interface RequestInit {
   body?: BodyInit | null
   cache?: RequestCache
@@ -294,6 +299,7 @@ export interface RequestInit {
   timeout?: number
   window?: any
   fetch?: any
+  jsonSerializer?: JsonSerializer
 }
 
 interface Body {

--- a/tests/general.test.ts
+++ b/tests/general.test.ts
@@ -177,5 +177,5 @@ test('case-insensitive content-type header for custom fetch', async () => {
   const client = new GraphQLClient(ctx.url, options)
   const result = await client.request('{ test }')
 
-  expect(result).toBe(testData.data)
+  expect(result).toEqual(testData.data)
 })

--- a/tests/json-serializer.test.ts
+++ b/tests/json-serializer.test.ts
@@ -1,0 +1,87 @@
+import { createReadStream } from 'fs'
+import { join } from 'path'
+import { GraphQLClient } from '../src'
+import { setupTestServer } from './__helpers'
+import * as Dom from '../src/types.dom'
+
+const ctx = setupTestServer()
+
+describe('jsonSerializer option', () => {
+  let serializer: Dom.JsonSerializer; 
+  const testData = { data: { test: { name: 'test' } } }
+  let fetch: any;
+
+  beforeEach(() => {
+    serializer = {
+      stringify: jest.fn(JSON.stringify),
+      parse: jest.fn(JSON.parse)
+    }
+    fetch = (url: string) => Promise.resolve({
+      headers: new Map([['Content-Type', 'application/json; charset=utf-8']]),
+      data: testData,
+      text: function () {
+        return JSON.stringify(testData)
+      },
+      ok: true,
+      status: 200,
+      url,
+    });
+  })
+  
+  test('is used for parsing response body', async () => {
+    const options: Dom.RequestInit = { jsonSerializer: serializer, fetch };
+    const client: GraphQLClient = new GraphQLClient(ctx.url, options);
+
+    const result = await client.request('{ test { name } }')
+    expect(result).toEqual(testData.data)
+    expect(serializer.parse).toBeCalledTimes(1)
+  })
+
+  describe('is used for serializing variables', () => {
+    const document = 'query getTest($name: String!) { test(name: $name) { name } }'
+    const simpleVariable = { name: 'test' }
+
+    let options: Dom.RequestInit
+    let client: GraphQLClient
+
+    const testSingleQuery = (expectedNumStringifyCalls = 1, variables: any = simpleVariable) => async () => {
+      await client.request(document, variables)
+      expect(serializer.stringify).toBeCalledTimes(expectedNumStringifyCalls)
+    }
+
+    const testBatchQuery = (expectedNumStringifyCalls: number, variables: any = simpleVariable) => async () => {
+      await client.batchRequests([{document, variables}])
+      expect(serializer.stringify).toBeCalledTimes(expectedNumStringifyCalls)
+    }
+
+    describe('request body', () => {
+      beforeEach(() => {
+        options = { jsonSerializer: serializer, fetch }
+        client = new GraphQLClient(ctx.url, options)
+      })
+
+      describe('without files', () => {
+        test('single query', testSingleQuery())
+        test('batch query', testBatchQuery(1))
+      })
+
+      describe('with files', () => {
+        const fileName = 'upload.test.ts'
+        const file = createReadStream(join(__dirname, fileName))
+
+        test('single query', testSingleQuery(2, {...simpleVariable, file}))
+        test('batch query', testBatchQuery(2, {...simpleVariable, file}))
+      })
+    })
+
+    describe('query string', () => {
+      beforeEach(() => {
+        options = { jsonSerializer: serializer, fetch, method: 'GET' }
+        client = new GraphQLClient(ctx.url, options)
+      })
+      
+      test('single query', testSingleQuery())
+      test('batch query', testBatchQuery(2)) // once for variable and once for query batch array
+    })
+  })
+})


### PR DESCRIPTION
**Context**

If you need to support numeric values larger than [Number.MAX_SAFE_INTEGER](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER), you can't use built-in JSON.parse/JSON.stringify.

> While most JSON parsers assume numeric values have same precision restrictions as IEEE 754 double, JSON specification does not say anything about number precision. Any floating point number in decimal (optionally scientific) notation is valid JSON value. It's a good idea to serialize values which might fall out of IEEE 754 integer precision as strings in your JSON api, but { "value" : 9223372036854775807}, for example, is still a valid RFC4627 JSON string, and in most JS runtimes the result of JSON.parse is this object: { value: 9223372036854776000 } 

[source](https://www.npmjs.com/package/json-bigint)

**Proposed solution**

Add a new optional option: `jsonSerializer`
